### PR TITLE
Port PINT v1.1 fixes to IPTA fork

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "ruamel.yaml",
-    "pint_pulsar>=1.1",
+    "pint_pulsar>=1.1.1",
     "enterprise-pulsar>=3.3.2",
     "enterprise-extensions>=v2.4.1",
     "pytest",
@@ -29,7 +29,7 @@ dependencies = [
     "numpy",
     "weasyprint",
     "pytest-xdist[psutil]>=2.3.0",
-    "jupyter",
+    "notebook",
     "seaborn",
     "gitpython",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "ruamel.yaml",
-    "pint_pulsar>=0.9.1",
+    "pint_pulsar>=1.1",
     "enterprise-pulsar>=3.3.2",
     "enterprise-extensions>=v2.4.1",
     "pytest",

--- a/src/pint_pal/noise_utils.py
+++ b/src/pint_pal/noise_utils.py
@@ -432,7 +432,7 @@ def add_noise_to_model(model, burn_frac = 0.25, save_corner = True, no_corner_pl
     #Setup and validate the timing model to ensure things are correct
     model.setup()
     model.validate()
-    model.noise_mtime = mtime.isot
+    model.meta['noise_mtime'] = mtime.isot
 
     if convert_equad_to_t2:
         from pint_pal.lite_utils import convert_enterprise_equads

--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -119,8 +119,8 @@ class TimingConfiguration:
         m = model.get_model(par_path,allow_name_mixing=True)
         match = re.search(r"#\s+Created:\s+(\S+)", open(par_path).read())
         if match:
-            m.meta["created_time"] = match.group(1)
-            log.info(f"Par file created: {m.meta["created_time"]}")
+            m.meta['created_time'] = match.group(1)
+            log.info(f"Par file created: {m.meta['created_time']}")
         m.file_mtime = Time(os.path.getmtime(par_path), format="unix").isot
 
 

--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -121,7 +121,7 @@ class TimingConfiguration:
         if match:
             m.meta['created_time'] = match.group(1)
             log.info(f"Par file created: {m.meta['created_time']}")
-        m.file_mtime = Time(os.path.getmtime(par_path), format="unix").isot
+        m.meta['file_mtime'] = Time(os.path.getmtime(par_path), format="unix").isot
 
 
         if m.PSR.value != self.get_source():

--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -119,8 +119,8 @@ class TimingConfiguration:
         m = model.get_model(par_path,allow_name_mixing=True)
         match = re.search(r"#\s+Created:\s+(\S+)", open(par_path).read())
         if match:
-            m.created_time = match.group(1)
-            log.info(f"Par file created: {m.created_time}")
+            m.meta["created_time"] = match.group(1)
+            log.info(f"Par file created: {m.meta["created_time"]}")
         m.file_mtime = Time(os.path.getmtime(par_path), format="unix").isot
 
 


### PR DESCRIPTION
In December, I merged a set of fixes from @JPGlaser that allowed PINT Pal to be used with PINT v1.1 (nanograv/pint_pal#95), but these were only applied to the NANOGrav version, since this IPTA fork was "frozen" for compatibility reasons. But the IPTA data combination group has recently had to adopt PINT v1.1.3 because of its newly added support for the NenuFAR observatory. So this PR ports the fixes in nanograv/pint_pal#95 to the IPTA fork to allow it to be used with PINT v1.1 and later.